### PR TITLE
chore(build): use layout.buildDirectory instead of buildDir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ contacts {
     }
 }
 
-configurations.all {
+configurations.configureEach {
     resolutionStrategy {
         // check for updates in modules every build
         cacheChangingModulesFor 0, 'seconds'
@@ -131,7 +131,7 @@ subprojects {
         from sourceSets.main.java
     }
 
-    task testJar(type: Jar) {
+    tasks.register('testJar', Jar) {
         archiveClassifier.set('test')
         from sourceSets.test.output
     }
@@ -221,7 +221,7 @@ subprojects {
 
         enabled = subprojects.isEmpty() && !srcDirs.isEmpty()
 
-        ext.outputDir = file("$buildDir/delombok")
+        ext.outputDir = layout.buildDirectory.dir("./delombok").get().asFile
         outputs.dir(outputDir)
         srcDirs.each {
             inputs.dir(it)
@@ -245,12 +245,12 @@ subprojects {
         reportLevel = Confidence.LOW
         ignoreFailures = false
         excludeFilter = rootProject.file('./spotbugs-exclude.xml')
-        reportsDir = rootProject.file("$rootProject.buildDir/reports/spotbugs/$project.name")
+        reportsDir = rootProject.file("$rootProject.layout.buildDirectory/reports/spotbugs/$project.name")
     }
     tasks.withType(SpotBugsTask).configureEach {
         reports {
-            html.enabled = true
-            xml.enabled = false
+            html.required = true
+            xml.required = false
         }
     }
 
@@ -259,7 +259,7 @@ subprojects {
         configFile = rootProject.file('./checkstyle.xml')
         maxErrors = 0
         ignoreFailures = false
-        reportsDir = rootProject.file("$rootProject.buildDir/reports/checkstyle/$project.name")
+        reportsDir = rootProject.file("$rootProject.layout.buildDirectory/reports/checkstyle/$project.name")
     }
     tasks.withType(Checkstyle).configureEach {
         reports {

--- a/spring-tor/spring-tor-http-client/src/integTest/java/org/tbk/tor/http/client/TorHttpClient5Test.java
+++ b/spring-tor/spring-tor-http-client/src/integTest/java/org/tbk/tor/http/client/TorHttpClient5Test.java
@@ -102,7 +102,8 @@ class TorHttpClient5Test {
 
         assertThat(expectedException.getMessage(), Matchers.anyOf(
                 containsString("Temporary failure in name resolution"),
-                containsString("Name or service not known")
+                containsString("Name or service not known"),
+                containsString("No address associated with hostname")
         ));
     }
 

--- a/spring-tor/spring-tor-http/src/integTest/java/org/tbk/tor/http/TorHttpClientTest.java
+++ b/spring-tor/spring-tor-http/src/integTest/java/org/tbk/tor/http/TorHttpClientTest.java
@@ -103,7 +103,8 @@ class TorHttpClientTest {
 
         assertThat(expectedException.getMessage(), Matchers.anyOf(
                 containsString("Temporary failure in name resolution"),
-                containsString("Name or service not known")
+                containsString("Name or service not known"),
+                containsString("No address associated with hostname")
         ));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration syntax to use modern Gradle API patterns.
  * Modernized build directory references and report paths.
  * Updated task registration for improved build management.

* **Tests**
  * Enhanced integration test error handling to accommodate additional exception message variations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->